### PR TITLE
Added an option to skip adding /var/lib/juju to juju-crashdump.

### DIFF
--- a/juju-crashdump
+++ b/juju-crashdump
@@ -28,7 +28,7 @@ from textwrap import dedent
 
 MAX_FILE_SIZE = 5000000 # 5MB max for files
 DIRECTORIES = [
-    '/var/lib/juju',
+    #'/var/lib/juju',  # Added below, if --small not passed.
     '/var/log',
     '/etc/ceph',
     '/etc/cinder',
@@ -228,6 +228,9 @@ def parse_args():
     parser.add_argument('-u', '--uniq',
                         help="Unique id for this crashdump. "
                         "We generate a uuid if this is not specified.")
+    parser.add_argument('-s', '--small', action='store_true',
+                        help="Make a 'small' crashdump, by skipping the contents "
+                        "of /var/lib/juju.")
     return parser.parse_args()
 
 
@@ -238,6 +241,8 @@ def main():
               "You must 'apt install' apport to use the 'bug' option. "
               "Aborting run.")
         return
+    if not opts.small:
+        DIRECTORIES.append('/var/lib/juju')
     collector = CrashCollector(
         model=opts.model,
         max_size=opts.max_file_size,


### PR DESCRIPTION
Useful for automated testing frameworks, which don't necessarily want to
create a huge tarball each time.

@johnsca, @kwmonroe Thinking about this, I think that it makes sense to include /var/lib/juju in juju-crashdump when it is run manually. You are trying to diagnose a problem, and saving off the state of the /var/lib/juju dir is useful for that diagnosis.

I don't think that it's so useful that it needs to be included in the automated tests, though. If you agree with this approach, the next step is to pass "-s" in matrix (and bundletester).

... and the next step after that might be to only crashdump when we have a test failure.