### PR TITLE
Allow overriding default timeout of 45 seconds.

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -121,7 +121,7 @@ def run_cmd(command, fatal=False, to_file=None):
         if to_file is not None:
             with open(to_file, 'wb') as fd:
                 fd.write(output)
-    except:
+    except subprocess.CalledProcessError:
         print('Command "%s" failed' % command)
         if fatal:
             sys.exit(1)


### PR DESCRIPTION
On larger models, this timeout value is too short. Making it
user specified allows flexibility.

This fixes issue #16.