### PR TITLE
collect /etc/cloud and /var/lib/cloud/seed.

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -33,6 +33,7 @@ DIRECTORIES = [
     '/etc/alternatives',
     '/etc/ceph',
     '/etc/cinder',
+    '/etc/cloud',
     '/etc/glance',
     '/etc/keystone',
     '/etc/netplan',
@@ -47,6 +48,7 @@ DIRECTORIES = [
     '/var/lib/charm',
     '/var/lib/libvirt/filesystems/plumgrid-data/log',
     '/var/lib/libvirt/filesystems/plumgrid/var/log',
+    '/var/lib/cloud/seed',
     '/var/log',
 ]
 


### PR DESCRIPTION
/etc/cloud contains two things of interest:
 a.) build.info which identifies ubuntu builds with a name and serial.
 b.) cloud-init config files which affect cloud-init's behavior.

/var/lib/cloud/seed contains the datasource NoCloud information that
is provided for lxd instances.