### PR TITLE
Correct pathing for addons juju scp.

### DIFF
--- a/jujucrashdump/addons.py
+++ b/jujucrashdump/addons.py
@@ -5,6 +5,7 @@ import shlex
 import yaml
 import sys
 import os
+import glob
 
 LOCAL = 'local'
 REMOTE = 'remote'
@@ -83,7 +84,8 @@ class CrashdumpAddon(object):
         """This will fetch the command, and push it to the units"""
         subprocess.check_call(self.local, shell=True, stdout=FNULL,
                               stderr=FNULL)
-        async_commands('juju scp -- -r . {}:%s' % location, units)
+        files = ' '.join(glob.glob('*'))
+        async_commands('juju scp -- -r  %s {}:%s' % (files, location), units)
 
     def run(self, units, context):
         """This will runt the remote command on the units"""


### PR DESCRIPTION
When running addons, juju fails to scp files to each machine
because "ERROR exit status 1 (scp: error: unexpected filename: .)"

This creates a list of files and directories in the current working
directory, and recursivly pushes them to the host.