### PR TITLE
Add /var/lib/juju/agents to --small dumps

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -366,7 +366,9 @@ def main():
               "You must 'apt install' apport to use the 'bug' option. "
               "Aborting run.")
         return
-    if not opts.small:
+    if opts.small:
+        DIRECTORIES.append('/var/lib/juju/agents')
+    else:
         DIRECTORIES.append('/var/lib/juju')
     collector = CrashCollector(
         model=opts.model,


### PR DESCRIPTION
The data in /var/lib/juju/agents is generally very small and
can easily be included into every crashdump.

Fixes: #29