### PR TITLE
Use multiple addons files

### DIFF
--- a/jujucrashdump/addons.py
+++ b/jujucrashdump/addons.py
@@ -16,7 +16,9 @@ FNULL = open(os.devnull, 'w')
 def do_addons(addons_file_path, enabled_addons, units, uniq):
     push_location = '/tmp/{uniq}/addons'.format(uniq=uniq)
     pull_location = '/tmp/{uniq}/addon_output'.format(uniq=uniq)
-    addons = load_addons(addons_file_path)
+    addons = {}
+    for addon_file in addons_file_path:
+        addons.update(load_addons(addon_file))
     if enabled_addons:
         async_commands('juju ssh {} "mkdir -p %s"' % push_location, units)
         async_commands('juju ssh {} "mkdir -p %s"' % pull_location, units)

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -351,7 +351,7 @@ def parse_args():
                         help='Enable the addon with the given name')
     parser.add_argument('-t', '--timeout', type=int, default='45',
                         help='Timeout in seconds for creating unit tarballs.')
-    parser.add_argument('--addons-file',  default=ADDONS_FILE_PATH,
+    parser.add_argument('--addons-file',  action='append',
                         help='Use this file for addon definitions')
     parser.add_argument('-j', '--journalctl', action='append',
                         help='Collect the journalctl logs for the systemd unit'
@@ -370,6 +370,9 @@ def main():
         DIRECTORIES.append('/var/lib/juju/agents')
     else:
         DIRECTORIES.append('/var/lib/juju')
+    # We want to load the default addons first, and give the
+    # option to overwrite them with newer addons if present.
+    opts.addons_file.insert(0, ADDONS_FILE_PATH)
     collector = CrashCollector(
         model=opts.model,
         max_size=opts.max_file_size,


### PR DESCRIPTION
Allow the user to use addons from the default addons.yaml and their own addons.yaml.