### PR TITLE
Add addons for juju_engine_report and juju config.

### DIFF
--- a/jujucrashdump/addons.yaml
+++ b/jujucrashdump/addons.yaml
@@ -10,3 +10,9 @@ debug-layer:
 inner:
     local: git clone https://github.com/juju/juju-crashdump.git
     remote: PYTHONPATH=juju-crashdump python3 juju-crashdump/jujucrashdump/crashdump.py -o {output} || true
+engine-report:
+    local: 'true'
+    remote: mkdir {output}/juju_introspection; . /etc/profile.d/juju-introspection.sh; juju_machine_lock > {output}/juju_introspection/juju_machine_lock.txt; juju_engine_report > {output}/juju_introspection/juju_engine_report.txt; for agent in $(grep -E '^\w' {output}/juju_introspection/juju_machine_lock.txt | cut -f 1 -d :); do juju_engine_report $agent > {output}/juju_introspection/juju_engine_report-$agent.txt; done;
+config:
+    local: juju status --format=json | jq -r '.applications | keys | .[]' | while read app; do juju config $app >> $app-config.yaml || true; done;
+    remote: "mkdir {output}/config; . /etc/profile.d/juju-introspection.sh; for app in $(juju_machine_lock | grep -E '^\\w' |sed 's/-[0-9]\\+:$//g' | sed 's/unit-//g'); do cp $app-config.yaml {output}/config; done;"

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -370,7 +370,7 @@ def parse_args():
     parser.add_argument('-t', '--timeout', type=int, default='45',
                         help='Timeout in seconds for creating unit tarballs.')
     parser.add_argument('--addons-file',  action='append',
-                        help='Use this file for addon definitions')
+                        help='Use this file for addon definitions', default=[])
     parser.add_argument('-j', '--journalctl', action='append',
                         help='Collect the journalctl logs for the systemd unit'
                              ' with the given name')


### PR DESCRIPTION
juju_engine_report is run for each unit and for the machine itself
and stored in a juju_introspection directory.

Configs are generated for each application and saved on in a
config dir for each machine.  Since the addon is optional,
the concern for private data can be assessed by the user.  See
lp:#1826449 for hiding private data in juju config.