### PR TITLE
Revert "Add /var/lib/juju/agents to --small dumps"

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -384,9 +384,7 @@ def main():
               "You must 'apt install' apport to use the 'bug' option. "
               "Aborting run.")
         return
-    if opts.small:
-        DIRECTORIES.append('/var/lib/juju/agents')
-    else:
+    if not opts.small:
         DIRECTORIES.append('/var/lib/juju')
     if not opts.addons_file:
         opts.addons_file = []


### PR DESCRIPTION
This reverts commit 8a557f4d478fc44d4ac1d2762b9428e8e7e9f492.

Turns out /var/lib/juju/agents adds several GB's to crashdumps
on large FCB deployments.

Fixes issue #37.