### PR TITLE
replace juju run and juju scp with ssh and scp

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ deps =
 commands = nosetests tests
 deps =
     nose
+    futures
+    pyaml
 
 [travis]
 python =


### PR DESCRIPTION
When unit is in error or blocked state juju run will not connect.
Using ssh instead allows to collect data regardless of juju agent
status.

solves #28 amd #26