### PR TITLE
Fix ssh/scp and yaml warning

### DIFF
--- a/jujucrashdump/addons.py
+++ b/jujucrashdump/addons.py
@@ -45,7 +45,7 @@ def tempdir(func):
 
 def load_addons(addons_file_path):
     with open(addons_file_path) as addons_file:
-        addon_specs = yaml.load(addons_file)
+        addon_specs = yaml.safe_load(addons_file)
     addons = {}
     for name, info in addon_specs.items():
         try:

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -64,7 +64,7 @@ def retrieve_single_unit_tarball(tuple_input):
     unique, machine, alias_group, all_machines = tuple_input
     unit_unique = uuid.uuid4()
     for ip in all_machines[machine]:
-        if run_cmd("%s %s:/tmp/juju-dump-%s.tar %s.tar"
+        if run_cmd("%s ubuntu@%s:/tmp/juju-dump-%s.tar %s.tar"
                    % (SCP_CMD, ip, unique, unit_unique)):
             break
     if '/' not in machine:
@@ -170,7 +170,7 @@ def run_ssh(host, timeout, ssh_cmd, cmd):
     # Each host can have several interfaces and IP addresses.
     # This cycles through them and uses the first working.
     for ip in host:
-        if run_cmd("timeout {}s {} {} sudo '{}'".format(
+        if run_cmd("timeout {}s {} ubuntu@{} sudo '{}'".format(
                    timeout, ssh_cmd, ip, cmd)):
             break
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,6 +9,7 @@ description: >
   access to the Juju model.
 confinement: classic
 grade: stable
+base: core18
 apps:
   juju-crashdump:
     command: bin/juju-crashdump
@@ -19,7 +20,7 @@ parts:
     build-packages: [lsb-release]
     stage-packages:
       - python-apport
-      - jq 
+      - jq
     python-packages:
       - pyyaml
     source: .


### PR DESCRIPTION
- Switch to yaml.safe_load()
- Fix ssh/scp failing by using the ubuntu user explicitly
- Switch snap to build from core18 base

Built and tested locally. Fixes these failures:
```
$ juju-crashdump -a debug-layer -a config
/snap/juju-crashdump/143/lib/python3.5/site-packages/jujucrashdump/addons.py:48: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  addon_specs = yaml.load(addons_file)
Command "timeout 45s ssh -o StrictHostKeyChecking=no -i ~/.local/share/juju/ssh/juju_id_rsa 54.237.153.136 sudo 'mkdir -p /tmp/994bee8b-ef0d-4cc0-aee9-930333a563f4/cmd_output;sudo netstat -taupn | grep LISTEN 2>/dev/null | sudo tee /tmp/994bee8b-ef0d-4cc0-aee9-930333a563f4/cmd_output/listening.txt || true'" failed
# ... many more similar failures