### PR TITLE
Fix config and debug-layer addons

### DIFF
--- a/jujucrashdump/addons.yaml
+++ b/jujucrashdump/addons.yaml
@@ -5,7 +5,11 @@ sosreport:
     local: git clone https://github.com/sosreport/sos.git
     remote: sudo ./sos/sosreport --batch --quiet --build --tmp-dir={output}
 debug-layer:
-    local: juju status --format=json | jq -r '.applications | keys | .[]' | while read app; do juju actions $app 2>/dev/null | grep -qE '^debug *Collect debug data$' && juju status --format=json | jq --arg app $app -r '.applications[$app].units | keys | .[]' >> debug-layer-units || true; done;
+    local: |
+      export PATH="$SNAP/usr/bin:$PATH"
+      juju status --format=json | jq -r '.applications | keys | .[]' | while read app; do
+        juju actions $app 2>/dev/null | grep -qE '^debug *Collect debug data$' && juju status --format=json | jq --arg app $app -r '.applications[$app].units | keys | .[]' >> debug-layer-units || true
+      done
     remote: for unit in $(cat debug-layer-units); do sudo juju-run $unit actions/debug; done; cp /home/ubuntu/debug-*.tar.gz {output} || true
 inner:
     local: git clone https://github.com/juju/juju-crashdump.git
@@ -14,5 +18,9 @@ engine-report:
     local: 'true'
     remote: mkdir {output}/juju_introspection; . /etc/profile.d/juju-introspection.sh; juju_machine_lock > {output}/juju_introspection/juju_machine_lock.txt; juju_engine_report > {output}/juju_introspection/juju_engine_report.txt; for agent in $(grep -E '^\w' {output}/juju_introspection/juju_machine_lock.txt | cut -f 1 -d :); do juju_engine_report $agent > {output}/juju_introspection/juju_engine_report-$agent.txt; done;
 config:
-    local: juju status --format=json | jq -r '.applications | keys | .[]' | while read app; do juju config $app >> $app-config.yaml || true; done;
+    local: |
+      export PATH="$SNAP/usr/bin:$PATH"
+      juju status --format=json | jq -r '.applications | keys | .[]' | while read app; do
+        juju config $app | cat >> $app-config.yaml || true
+      done
     remote: "mkdir {output}/config; . /etc/profile.d/juju-introspection.sh; for app in $(juju_machine_lock | grep -E '^\\w' |sed 's/-[0-9]\\+:$//g' | sed 's/unit-//g'); do cp $app-config.yaml {output}/config; done;"


### PR DESCRIPTION
Fixes https://github.com/juju/juju-crashdump/issues/50

---

#### Added `$SNAP/usr/bin` to PATH in the debug-layer and config addons.

This allows those addons to use the `jq` binary that's bundled with the snap.

#### Added `cat` somewhere in the config addon for mysterious reasons.

I don't know why, but when it was like this:
```
juju config $app >> $app-config.yaml
```

I was getting this output from the script during debug:
```
ERROR write /dev/stdout: permission denied
```

But when I changed it to this:
```
juju config $app | cat >> $app-config.yaml
```

it started working. Yay?!

---

Tested with these changes by running:

```
juju-crashdump --small -a debug-layer -a config
```

against a live Charmed Kubernetes cluster. I confirmed that the resulting .tar.gz included debug action output and application config.