### PR TITLE
Grab juju-db logs by default.

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -58,6 +58,7 @@ DIRECTORIES = [
     '/var/log',
     '/var/snap/simplestreams/common/sstream-mirror-glance.log',
     '/var/crash',
+    '/var/snap/juju-db/common/logs/',
 ]
 
 SSH_PARM = ' -o StrictHostKeyChecking=no\


### PR DESCRIPTION
This is useful to see why mongodb is crashing.