### PR TITLE
Explicitly include dates in debug-log

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -161,7 +161,7 @@ def juju_status():
 
 
 def juju_debuglog():
-    juju_cmd('debug-log --replay --no-tail', to_file='debug_log.txt')
+    juju_cmd('debug-log --date --replay --no-tail', to_file='debug_log.txt')
 
 
 def juju_model_defaults():


### PR DESCRIPTION
A bug/request has been raised against Juju project as LP: #1907515.
However, explicitly having dates always is still nice to have in
juju-crashdump as the log may be stretched across multiple days.
    
Closes: #62