### PR TITLE
prevent scp to be stuck indefinitely

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -67,7 +67,7 @@ SSH_PARM = " -o StrictHostKeyChecking=no\
  -i ~/.local/share/juju/ssh/juju_id_rsa"
 
 SSH_CMD = "ssh" + SSH_PARM
-SCP_CMD = "scp" + SSH_PARM
+SCP_CMD = "timeout -v 10m scp" + SSH_PARM
 
 
 def retrieve_single_unit_tarball(tuple_input):


### PR DESCRIPTION
Sometimes scp stays stuck for hours and we have to cancel the job.