### PR TITLE
call run_psaux()

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -385,6 +385,7 @@ class CrashCollector(object):
         self.get_caas_stuff()
         self.run_addons()
         self.run_listening()
+        self.run_psaux()
         self.run_journalctl()
         self.create_unit_tarballs()
         self.retrieve_unit_tarballs()


### PR DESCRIPTION
Method was created in a previous commit but it was not called.