### PR TITLE
Add option to specify unit-dump-location

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -77,7 +77,8 @@ def retrieve_single_unit_tarball(tuple_input):
     unit_unique = uuid.uuid4()
     for ip in all_machines[machine]:
         if run_cmd(
-            "{scp} ubuntu@{ip}:{dump_location}/{unique}/juju-dump-{unique}.tar {unit_unique}.tar".format(
+            "{scp} ubuntu@{ip}:{dump_location}/{unique}/juju-dump-{unique}.tar {unit_unique}.tar"
+            .format(
                 scp=SCP_CMD,
                 ip=ip,
                 dump_location=unit_dump_location,
@@ -214,7 +215,7 @@ class CrashCollector(object):
         compression="xz",
         timeout=45,
         journalctl=None,
-        unit_dump_location=None,
+        unit_dump_location="/tmp",
     ):
         if model:
             set_model(model)

--- a/tests/test_jujucrashdump_crashdump.py
+++ b/tests/test_jujucrashdump_crashdump.py
@@ -18,10 +18,10 @@ import tests.utils as utils
 
 import jujucrashdump.crashdump as crashdump
 
-class TestCrashCollector(utils.BaseTestCase):
 
+class TestCrashCollector(utils.BaseTestCase):
     def setUp(self):
-        self.target = crashdump.CrashCollector('aModel', 42, ['extra_dir'])
+        self.target = crashdump.CrashCollector("aModel", 42, ["extra_dir"])
         self._patches = {}
         self._patches_start = {}
 
@@ -42,36 +42,27 @@ class TestCrashCollector(utils.BaseTestCase):
         setattr(self, attr, started)
 
     def test_create_unit_tarballs(self):
-        self.patch_object(crashdump, 'DIRECTORIES')
-        self.target.uniq = 'fake-uuid'
-        self.patch_target('_run_all')
-        self.DIRECTORIES.__iter__.return_value = ['dir']
+        self.patch_object(crashdump, "DIRECTORIES")
+        self.target.uniq = "fake-uuid"
+        self.patch_target("_run_all")
+        self.DIRECTORIES.__iter__.return_value = ["dir"]
         self.target.create_unit_tarballs()
-        self._run_all.assert_called_once_with(
-            'sudo find dir extra_dir /var/lib/lxd/containers/*/rootfsdir '
-            '/var/lib/lxd/containers/*/rootfsextra_dir -mount -type f '
-            '-size -42c -o -size 42c 2>/dev/null | '
-            'sudo tar -pcf /tmp/juju-dump-fake-uuid.tar '
-            '--files-from - 2>/dev/null;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/cmd_output . || true;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/ journalctl || true;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/addon_output . || true')
+        self._run_all.assert_called_with(
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/cmd_output . || true;"
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/ journalctl || true;"
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/addon_output . || true"
+        )
         self._run_all.reset_mock()
-        self.target.exclude = ('exc0', 'exc1')
+        self.target.exclude = ("exc0", "exc1")
         self.target.create_unit_tarballs()
-        self._run_all.assert_called_once_with(
-            'sudo find dir extra_dir /var/lib/lxd/containers/*/rootfsdir '
-            '/var/lib/lxd/containers/*/rootfsextra_dir -mount -type f '
-            '-size -42c -o -size 42c 2>/dev/null | '
-            'sudo tar -pcf /tmp/juju-dump-fake-uuid.tar '
-            '--exclude exc0 --exclude exc1 '
-            '--files-from - 2>/dev/null;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/cmd_output . || true;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/ journalctl || true;'
-            'sudo tar --append -f /tmp/juju-dump-fake-uuid.tar '
-            '-C /tmp/fake-uuid/addon_output . || true')
+        self._run_all.assert_called_with(
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/cmd_output . || true;"
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/ journalctl || true;"
+            "tar --append -f /tmp/fake-uuid/juju-dump-fake-uuid.tar "
+            "-C /tmp/fake-uuid/addon_output . || true"
+        )


### PR DESCRIPTION
When juju-crashdump is run against a secured environment (CIS hardened), we run into all kinds of different permission errors.
This change adds an option to specify where to generate the crashdump on the units so that we can put it somewhere sane like /home/ubuntu while defaulting to the original behavior of dumping things in /tmp.