### PR TITLE
Fix addon_output dir not creating when --no-root flag not used

### DIFF
--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -311,6 +311,7 @@ class CrashCollector(object):
         directories.append(".")
 
         tar_cmd = (
+            "mkdir -p {dump_location}/{uniq}/addon_output; "
             "cd {dump_location}/{uniq}/addon_output; "
             "{sudo}find {dirs} -mount -type f -size -{max_size}c -o -size "
             "{max_size}c 2>/dev/null | {sudo}tar -pcf ../juju-dump-{uniq}.tar"

--- a/tests/test_jujucrashdump_crashdump.py
+++ b/tests/test_jujucrashdump_crashdump.py
@@ -48,6 +48,7 @@ class TestCrashCollector(utils.BaseTestCase):
         self.DIRECTORIES.__iter__.return_value = ["dir"]
         self.target.create_unit_tarballs()
         self._run_all.assert_called_with(
+            "mkdir -p /tmp/fake-uuid/addon_output; "
             "cd /tmp/fake-uuid/addon_output; find dir extra_dir "
             "/var/lib/lxd/containers/*/rootfsdir "
             "/var/lib/lxd/containers/*/rootfsextra_dir . -mount "
@@ -58,6 +59,7 @@ class TestCrashCollector(utils.BaseTestCase):
         self.target.exclude = ("exc0", "exc1")
         self.target.create_unit_tarballs()
         self._run_all.assert_called_with(
+            "mkdir -p /tmp/fake-uuid/addon_output; "
             "cd /tmp/fake-uuid/addon_output; find dir extra_dir "
             "/var/lib/lxd/containers/*/rootfsdir "
             "/var/lib/lxd/containers/*/rootfsextra_dir . -mount "


### PR DESCRIPTION
Fixes bug where addon_output directory is only created when `--as-root` is used, which causes the log collection to fail in some cases.