### PR TITLE
Use ssh controller proxy

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/jujucrashdump/addons.py
+++ b/jujucrashdump/addons.py
@@ -22,8 +22,8 @@ def do_addons(
     units = [{"unit": u} for u in units]
     for addon_file in addons_file_path:
         addons.update(load_addons(addon_file, enabled_addons, as_root))
-    async_commands('juju ssh {machine} "mkdir -p %s"' % push_location, machines)
-    async_commands('juju ssh {machine} "mkdir -p %s"' % pull_location, machines)
+    async_commands('juju ssh --proxy {machine} "mkdir -p %s"' % push_location, machines)
+    async_commands('juju ssh --proxy {machine} "mkdir -p %s"' % pull_location, machines)
     for addon in enabled_addons:
         if addon not in addons:
             raise AttributeError(
@@ -114,7 +114,8 @@ class CrashdumpAddon(object):
             return False
         files = " ".join(glob.glob("*"))
         async_commands(
-            "juju scp -- -r  %s {machine}:%s" % (files, context["location"]), machines
+            "juju scp --proxy -- -r  %s {machine}:%s" % (files, context["location"]),
+            machines,
         )
         return True
 
@@ -125,7 +126,7 @@ class CrashdumpAddon(object):
         if len(fields) > 1 or not fields[0] in ["machine", "unit"]:
             raise ValueError("Invalid fields for local-per-unit: %s" % fields)
         command = (
-            "{cmd} | juju ssh {field} 'mkdir {output}/{name}; "
+            "{cmd} | juju ssh --proxy {field} 'mkdir {output}/{name}; "
             "cat > {output}/{name}/$(echo {field} | tr / _)'"
         ).format(cmd=cmd, name=self.name, field="{%s}" % fields[0], **context)
         async_commands(command, vars()["%ss" % fields[0]], shell=True)
@@ -135,5 +136,5 @@ class CrashdumpAddon(object):
         """This will runt the remote command on the machines"""
         remote_cmd = '"cd {location}; %s"' % command.format(**context)
         remote_cmd = remote_cmd.format(**context)
-        async_commands("juju ssh {machine} -- %s" % remote_cmd, machines)
+        async_commands("juju ssh --proxy {machine} -- %s" % remote_cmd, machines)
         return True

--- a/jujucrashdump/addons.py
+++ b/jujucrashdump/addons.py
@@ -82,6 +82,9 @@ def async_commands(command, contexts, timeout=45, shell=False):
                 args,
             ]
         )
+        # The juju controller will only allow 10 connections at once
+        if len(procs) > 9:
+            procs[-10][0].communicate()
     for proc in procs:
         proc[0].communicate()
         if proc[0].returncode != 0:

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -67,11 +67,8 @@ DIRECTORIES = [
     "/var/snap/lxd/common/lxd/logs/",
 ]
 
-SSH_PARM = " -o StrictHostKeyChecking=no\
- -i ~/.local/share/juju/ssh/juju_id_rsa"
-
-SSH_CMD = "ssh" + SSH_PARM
-SCP_CMD = "scp" + SSH_PARM
+SSH_CMD = "juju ssh --proxy"
+SCP_CMD = "juju scp --proxy"
 
 
 def retrieve_single_unit_tarball(tuple_input):

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python2
-# this is python2/3 compatible, but the following bug breaks us...
-# https://bugs.launchpad.net/ubuntu/+source/python-launchpadlib/+bug/1425575
+#!/usr/bin/env python3
 
 # you also might need to $ sudo apt install python-apport
 

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -15,6 +15,7 @@ import uuid
 import yaml
 import concurrent.futures
 import logging
+import ssh_agent_setup
 from collections import defaultdict
 from os.path import expanduser
 
@@ -247,7 +248,10 @@ class CrashCollector(object):
         self.unit_dump_location = unit_dump_location
         self.as_root = as_root
         self._machines = None
-        run_cmd("ssh-add ~/.local/share/juju/ssh/juju_id_rsa")
+        ssh_agent_setup.setup()
+        ssh_agent_setup.add_key(
+            os.path.join(os.path.expanduser("~"), ".local/share/juju/ssh/juju_id_rsa")
+        )
 
     def get_all(self):
         if self._machines:
@@ -354,9 +358,6 @@ class CrashCollector(object):
             uniq=self.uniq,
             sudo="sudo " if self.as_root else "",
             dump_location=self.unit_dump_location,
-        )
-        self._run_all(
-            "rm -rf {dump_location}".format(dump_location=self.unit_dump_location)
         )
         self._run_all(
             "mkdir -p {dump_location}/{uniq}".format(

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -281,12 +281,16 @@ class CrashCollector(object):
                         # full brought up yet.
                         pass
 
+        # _machines is now a list of partial ssh commands, for example:
+        # ["ubuntu@x.x.x.x", "-J ubuntu@y.y.y.y ubuntu@x.x.x.x"]
+        # the proxy jumps are through the controller machines since the machines
+        # themselves may not be accessible directly
         self._machines = self._add_proxy_jumps(machines)
         return self._machines
 
     def _add_proxy_jumps(self, machines):
         controller_ips = []
-        for _, info in self.controller_status.get("machines", {}).items():
+        for info in self.controller_status.get("machines", {}).values():
             controller_ips.extend(info.get("ip-addresses", []))
 
         for machine, ips in machines.items():

--- a/jujucrashdump/crashdump.py
+++ b/jujucrashdump/crashdump.py
@@ -16,6 +16,7 @@ import yaml
 import concurrent.futures
 import logging
 import ssh_agent_setup
+
 from collections import defaultdict
 from os.path import expanduser
 
@@ -200,10 +201,10 @@ def juju_storage_pools():
 def run_ssh(host, timeout, ssh_cmd, cmd):
     # Each host can have several interfaces and IP addresses.
     # This cycles through them and uses the first working.
-    for i, ip in enumerate(host):
+    for ip in host:
         if run_cmd("timeout {}s {} {} '{}'".format(timeout, ssh_cmd, ip, cmd)):
-            # If successful, try this host first next time
-            host.insert(0, host.pop(i))
+            # If successful, no need to try the other hosts again
+            host = [ip]
             break
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+ssh-agent-setup

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,4 +23,5 @@ parts:
       - jq
     python-packages:
       - pyyaml
+      - ssh-agent-setup
     source: .

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,18 +9,17 @@ description: >
   access to the Juju model.
 confinement: classic
 grade: stable
-base: core18
+base: core22
 apps:
   juju-crashdump:
     command: bin/juju-crashdump
 parts:
   juju-crashdump:
     plugin: python
-    python-version: python3
-    build-packages: [lsb-release]
     stage-packages:
-      - python-apport
+      - python3-apport
       - jq
+      - python3.10-minimal
     python-packages:
       - pyyaml
       - ssh-agent-setup

--- a/tests/test_jujucrashdump_crashdump.py
+++ b/tests/test_jujucrashdump_crashdump.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Canonical Ltd
+# Copyright 2023 Canonical Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ import jujucrashdump.crashdump as crashdump
 
 
 class TestCrashCollector(TestCase):
-    def setUp(self):
+    @mock.patch.object(crashdump.ssh_agent_setup, "add_key")
+    def setUp(self, mock_add_key):
         self.target = crashdump.CrashCollector("aModel", 42, ["extra_dir"])
         self._patches = {}
         self._patches_start = {}

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands = pytest
 deps =
     futures
     mock
-    pyaml
+    PyYAML
     pytest
     -r requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     mock
     pyaml
     pytest
+    -r requirements.txt
 
 [travis]
 python =


### PR DESCRIPTION
Since recently, workloads on OpenStack controllers do not get a public IP. In order to still get the crashdumps for workloads on OpenStack we need to use the `--proxy` option when using `juju scp` or `juju ssh`. We need to make a proxy jump through the juju controllers for vanilla ssh commands. This requires slightly different ssh-key handling, which is assisted by the `ssh-agent-setup` package.

The unittests are updated from nose to pytest and the formatter `black` is run against all .py files.