### PR TITLE
Make snap compatible with focal

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,7 +20,11 @@ parts:
       - python3-apport
       - jq
       - python3.10-minimal
+      - libpython3.10-minimal
+      - libpython3.10-stdlib
     python-packages:
       - pyyaml
       - ssh-agent-setup
     source: .
+    build-attributes:
+      - enable-patchelf


### PR DESCRIPTION
The current build of the snap only works on jammy, some updates to the snapcraft definition are necessary to get it running on focal too.